### PR TITLE
Add list cmd

### DIFF
--- a/cmd/list/list_cmd.go
+++ b/cmd/list/list_cmd.go
@@ -1,0 +1,27 @@
+package list
+
+import (
+	"log"
+
+	"github.com/KKogaa/rio/internal/core/services"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var ListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists all the rio specs in the working directory for use with the send cmd",
+	Run: func(cmd *cobra.Command, args []string) {
+		fileService := services.NewFileService()
+
+		list, err := fileService.SearchCwd()
+		if err != nil {
+			log.Fatal(err)
+		}
+		green := color.New(color.FgGreen)
+		green.Println("List of specs in cwd:")
+		for _, spec := range list {
+			green.Printf("%-15s %-15s %x\n", spec.SpecName, spec.Filename, spec.Hash)
+		}
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/KKogaa/rio/cmd/create"
+	"github.com/KKogaa/rio/cmd/list"
 	"github.com/KKogaa/rio/cmd/send"
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,7 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	rootCmd.AddCommand(send.SendCmd)
 	rootCmd.AddCommand(create.CreateCmd)
+	rootCmd.AddCommand(list.ListCmd)
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("there was an error executing the cli: %s", err)
 	}

--- a/internal/core/entities/spec.go
+++ b/internal/core/entities/spec.go
@@ -1,0 +1,27 @@
+package entities
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+)
+
+type Spec struct {
+	Filename string
+	SpecName string
+	Hash     [32]byte
+}
+
+func CreateSpec(request Request, filename string) (Spec, error) {
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	shaSum := sha256.Sum256(jsonData)
+	spec := Spec{
+		Filename: filename,
+		SpecName: request.Name,
+		Hash:     shaSum,
+	}
+	return spec, nil
+}

--- a/internal/core/services/file_service.go
+++ b/internal/core/services/file_service.go
@@ -72,6 +72,32 @@ func (f *FileService) CreateRequestFile(filename string, name string,
 	return file.Name(), nil
 }
 
+func (f *FileService) SearchCwd() ([]entities.Spec, error) {
+	files, err := os.ReadDir(".")
+	if err != nil {
+		return []entities.Spec{}, err
+	}
+
+	list := []entities.Spec{}
+	for _, file := range files {
+		filename := file.Name()
+		if filepath.Ext(filename) != ".json" {
+			continue
+		}
+
+		request, err := f.GetRequestFromFile(filename)
+		if err != nil {
+			return list, err
+		}
+		newSpec, err := entities.CreateSpec(request, filename)
+		if err != nil {
+			return list, err
+		}
+		list = append(list, newSpec)
+	}
+	return list, err
+}
+
 func (f *FileService) SearchForSpec(name string) (entities.Request, error) {
 	// iterate overt the current working directory and find all the json files
 	files, err := os.ReadDir(".")


### PR DESCRIPTION
Implements #5 
Lists all rio specs by name, filename, and hash.
The hash will help to identify it when using the send cmd in case there are identical named specs